### PR TITLE
Filter redmine issues based on analysis date.

### DIFF
--- a/src/main/java/org/sonar/plugins/redmine/RedmineSensor.java
+++ b/src/main/java/org/sonar/plugins/redmine/RedmineSensor.java
@@ -53,7 +53,7 @@ public class RedmineSensor implements Sensor {
   public void analyse(Project project, SensorContext context) {
     try {
       redmineAdapter.connectToHost(redmineSettings.getHost(), redmineSettings.getApiAccessKey());
-      Map<String, Integer> issuesByPriority = redmineAdapter.collectProjectIssuesByPriority(redmineSettings.getProjectKey());
+      Map<String, Integer> issuesByPriority = redmineAdapter.collectProjectIssuesByPriority(redmineSettings.getProjectKey(), project.getAnalysisDate());
       double totalIssues = 0;
       PropertiesBuilder<String, Integer> distribution = new PropertiesBuilder<String, Integer>();
       for (Map.Entry<String, Integer> entry : issuesByPriority.entrySet()) {

--- a/src/test/java/org/sonar/plugins/redmine/RedmineSensorTest.java
+++ b/src/test/java/org/sonar/plugins/redmine/RedmineSensorTest.java
@@ -62,7 +62,7 @@ public class RedmineSensorTest {
     issuesByPriority.put("Normal", 2);
     issuesByPriority.put("Urgent", 1);
     doNothing().when(redmineAdapter).connectToHost("http://my.Redmine.server", "project_key");
-    when(redmineAdapter.collectProjectIssuesByPriority("project_key")).thenReturn(issuesByPriority);
+    when(redmineAdapter.collectProjectIssuesByPriority("project_key", null)).thenReturn(issuesByPriority);
     redmineSettings.setHost("http://my.Redmine.server");
     redmineSettings.setApiAccessKey("api_access_key");
     redmineSettings.setProjectKey("project_key");

--- a/src/test/java/org/sonar/plugins/redmine/client/RedmineAdapterTest.java
+++ b/src/test/java/org/sonar/plugins/redmine/client/RedmineAdapterTest.java
@@ -34,6 +34,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
+import static org.mockito.Matchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import org.powermock.api.mockito.PowerMockito;
@@ -206,10 +208,10 @@ public class RedmineAdapterTest {
     when(issue3.getPriorityText()).thenReturn("P1");
     
     List<Issue> issues = ImmutableList.of(issue1, issue2, issue3);
-    
-    when(redmineManager.getIssues(PROJECT_KEY, null)).thenReturn(issues);
+
+    when(redmineManager.getIssues(argThat(hasEntry("project_id", PROJECT_KEY)))).thenReturn(issues);
     redmineAdapter.connectToHost(HOST, APIKEY);
-    Map<String,Integer> issuesPerPriority = redmineAdapter.collectProjectIssuesByPriority(PROJECT_KEY);
+    Map<String,Integer> issuesPerPriority = redmineAdapter.collectProjectIssuesByPriority(PROJECT_KEY, null);
     
     assertThat(issuesPerPriority).hasSize(2).contains(MapEntry.entry("P1", 2)).contains(MapEntry.entry("P2", 1));
   }


### PR DESCRIPTION
If project analysis date is specified, get only issues that were created before that date and closed after this date.
This allows retrieving only the issues that were open at the specified date.
