### PR TITLE
Fixed i18n api_key.global.is_set and .not_set

### DIFF
--- a/src/main/resources/org/sonar/l10n/redmine.properties
+++ b/src/main/resources/org/sonar/l10n/redmine.properties
@@ -58,8 +58,8 @@ page.redmine_configuration.settings.url.global=Global configured Redmine URL
 page.redmine_configuration.settings.url.global.not_set=Global Redmine URL is not configured.
 page.redmine_configuration.settings.url.description=Complete URL to Redmine, examples: http://demo.redmine.org or http://localhost/path/to/redmine
 page.redmine_configuration.settings.api_key=API key
-page.redmine_configuration.settings.api_key.global.is_set=Global API key is not configured.
-page.redmine_configuration.settings.api_key.global.not_set=Global API key is configured.
+page.redmine_configuration.settings.api_key.global.is_set=Global API key is configured.
+page.redmine_configuration.settings.api_key.global.not_set=Global API key is not configured.
 page.redmine_configuration.settings.api_key.user=User resolved with the API key
 page.redmine_configuration.settings.api_key.description=API key to access the REST API as authorized user.
 


### PR DESCRIPTION
The following property values were exchanged: page.redmine_configuration.settings.api_key.global.is_set and page.redmine_configuration.settings.api_key.global.not_set
